### PR TITLE
Shippable build fails because of -f flag used with docker tag

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -23,8 +23,8 @@ build:
     - docker pull nrgi/rc-admin:$BRANCH || echo 'Cache not available'
     
     - docker build -t nrgi/rc-admin:$BRANCH.$COMMIT .
-    # Create the `latest` tag and force it in case the tag is already there from a previous build
-    - docker tag -f nrgi/rc-admin:$BRANCH.$COMMIT nrgi/rc-admin:$BRANCH
+    # Create the `latest` tag
+    - docker tag nrgi/rc-admin:$BRANCH.$COMMIT nrgi/rc-admin:$BRANCH
   
     - docker push nrgi/rc-admin:$BRANCH
     - docker push nrgi/rc-admin:$BRANCH.$COMMIT


### PR DESCRIPTION
## Why
Newest versions of docker do not support -f flag with docker tag. 

## What
- [x] remove -f flag when doing docker tag -f in .shippable  

## Notes
This occurred when adding issue_template.md to the repo.
https://forums.docker.com/t/force-tag-f-option-removed/18782
Shippable build broken by this : https://app.shippable.com/github/NRGI/resourcecontracts.org/runs/1591/1/console