### PR TITLE
Published/unpublished state for contract metadata/text/annotations is not properly determined

### DIFF
--- a/app/Nrgi/Mturk/Repositories/Activity/ActivityRepository.php
+++ b/app/Nrgi/Mturk/Repositories/Activity/ActivityRepository.php
@@ -90,14 +90,14 @@ class ActivityRepository implements ActivityRepositoryInterface
     }
 
     /**
-     * Get the first row where status is published
+     * Get full info on latest published event for the given contract.
      *
      * @param $id
      * @param $element
      *
      * @return activityLog
      */
-    public function getPublishedInfo($id, $element)
+    public function getLatestPublicationEvent($id, $element)
     {
         $query = $this->activityLog->select('*')->with('user')
                                    ->where('contract_id', $id)

--- a/app/Nrgi/Mturk/Repositories/Activity/ActivityRepository.php
+++ b/app/Nrgi/Mturk/Repositories/Activity/ActivityRepository.php
@@ -127,7 +127,7 @@ class ActivityRepository implements ActivityRepositoryInterface
                                        "(message_params->>'new_status' = 'published' or message_params->>'new_status' = 'unpublished' )"
                                    )
                                    ->whereRaw(sprintf("message_params->>'type' = '%s'", $element))
-                                   ->orderBy("created_at", "asc");
+                                   ->orderBy("created_at", "desc");
 
 
         $result = $query->first();

--- a/app/Nrgi/Mturk/Repositories/Activity/ActivityRepository.php
+++ b/app/Nrgi/Mturk/Repositories/Activity/ActivityRepository.php
@@ -112,6 +112,22 @@ class ActivityRepository implements ActivityRepositoryInterface
     }
 
     /**
+     * @param $id
+     * @param $element
+     * @return mixed|void
+     */
+    public function getFirstPublicationEvent($id, $element)
+    {
+        $query = $this->activityLog->select('*')->with('user')
+            ->where('contract_id', $id)
+            ->whereRaw("message_params->>'new_status' = 'published'")
+            ->whereRaw(sprintf("message_params->>'type' = '%s'", $element))
+            ->orderBy("created_at", "asc");
+
+        return $query->first();
+    }
+
+    /**
      * write brief description
      *
      * @param $id

--- a/app/Nrgi/Mturk/Repositories/Activity/ActivityRepositoryInterface.php
+++ b/app/Nrgi/Mturk/Repositories/Activity/ActivityRepositoryInterface.php
@@ -30,12 +30,12 @@ interface ActivityRepositoryInterface
     public function countByUser($user_id);
 
     /**
-     * Get the first row where status is published
+     * Get full info on latest published event for the given contract.
      * @param $id
      * @param $element
      * @return activityLog
      */
-    public function getPublishedInfo($id, $element);
+    public function getLatestPublicationEvent($id, $element);
 
     /**
      * write brief description

--- a/app/Nrgi/Mturk/Repositories/Activity/ActivityRepositoryInterface.php
+++ b/app/Nrgi/Mturk/Repositories/Activity/ActivityRepositoryInterface.php
@@ -44,4 +44,13 @@ interface ActivityRepositoryInterface
      * @return activityLog
      */
     public function getElementState($id, $element);
+
+    /**
+     * Returns details on the first time the element was published.
+     *
+     * @param $id
+     * @param $element
+     * @return mixed
+     */
+    public function getFirstPublicationEvent($id, $element);
 }

--- a/app/Nrgi/Mturk/Services/ActivityService.php
+++ b/app/Nrgi/Mturk/Services/ActivityService.php
@@ -105,7 +105,10 @@ class ActivityService
                 $data[$element] = 'published';
 
                 if($element=='metadata') {
-                    $data['metadata_published_at'] = $type->created_at;
+                    // This is used by the recent documents feature that requires the first date of publication instead
+                    // of the latest.
+                    $first_publication = $this->activity->getFirstPublicationEvent($id, $element);
+                    $data['metadata_published_at'] = $first_publication->created_at;
                 }
             } else {
                 if ($element == 'annotation') {

--- a/app/Nrgi/Mturk/Services/ActivityService.php
+++ b/app/Nrgi/Mturk/Services/ActivityService.php
@@ -70,18 +70,18 @@ class ActivityService
     }
 
     /**
-     * Get published Information
+     * Get latest published information.
      *
      * @param $id
      *
      * @return array
      */
-    public function getPublishedInfo($id)
+    public function getLatestPublishedInfo($id)
     {
         $elements = ["metadata", "text", "annotation"];
         $data     = [];
         foreach ($elements as $element) {
-            $data[$element] = $this->activity->getPublishedInfo($id, $element);
+            $data[$element] = $this->activity->getLatestPublicationEvent($id, $element);
         }
 
         return $data;

--- a/app/Nrgi/Services/Contract/ContractService.php
+++ b/app/Nrgi/Services/Contract/ContractService.php
@@ -1307,7 +1307,7 @@ class ContractService
      */
     public function getPublishedInformation($id)
     {
-        $data        = $this->activityService->getPublishedInfo($id);
+        $data        = $this->activityService->getLatestPublishedInfo($id);
         $information = [];
 
         foreach ($data as $element => $info) {


### PR DESCRIPTION
## Why
It should be clear from the admin UI if the state of a contract's metadata/text/annotations is published or not. At the moment the UI is confusing, showing both `Publish` and `Unpublish` active buttons:

<img width="1359" alt="Screen Shot 2020-12-18 at 23 12 32" src="https://user-images.githubusercontent.com/15313824/102693685-13e61100-4225-11eb-9eea-31486d54ca3e.png">

This also affects the bulk index command which sees contracts as published even though they were unpublished for editing. As a result, a reindexing process will publish contracts that were supposed to be unpublished.

## What
- [ ] the state of a contract's metadata/text/annotations is properly determined based on the last activity performed on them and that reflects in the admin UI and for the bulk index command.

## Notes
Published/unpublished state determination was changed with the introduction of the Recent Contracts feature. I understand that for recent contracts we want to filter based on the **first** date of publication.

The code was changed for that but it introduced a side effect where the state of metadata is also computed based on the first publication event instead of looking at the last published/unpublished activity.

This is where the code was changed: https://github.com/NRGI/resourcecontracts.org/commit/81e4fa25e24d2cf12eb107c533b0b57acf58c99d. The change at line 130 introduced the side effect.