### PR TITLE
Speed up loading of contract pages on RC admin

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -120,7 +120,7 @@ return array(
         'db' => array(
             'with_params'       => true,   // Render SQL with the parameters substituted
             'timeline'          => false,  // Add the queries to the timeline
-            'backtrace'         => false,  // EXPERIMENTAL: Use a backtrace to find the origin of the query in your files.
+            'backtrace'         => true,  // EXPERIMENTAL: Use a backtrace to find the origin of the query in your files.
             'explain' => array(            // EXPERIMENTAL: Show EXPLAIN output on queries
                 'enabled' => false,
                 'types' => array('SELECT'), // array('SELECT', 'INSERT', 'UPDATE', 'DELETE'); for MySQL 5.6.3+

--- a/resources/views/contract/partials/show/script.blade.php
+++ b/resources/views/contract/partials/show/script.blade.php
@@ -31,7 +31,8 @@
 
 <?php
 $pages = [];
-for ($i = 1; $i <= $contract->pages()->count(); $i++) {
+$page_count = $contract->pages()->count();
+for ($i = 1; $i <= $page_count; $i++) {
 	$pages[$i] = $i;
 }
 ?>


### PR DESCRIPTION
## Why
Pages for contracts that have lots of pages are slow to load on the admin site.

## What
- [ ] load speed is optimized for contracts with large numbers of pages

## Notes
The backend currently does a database query for each page in the contract to determine the number of pages.