### PR TITLE
Ensure MTurk log file is owned by `www-data`

### DIFF
--- a/app/Nrgi/Mturk/Services/MechanicalTurkV2.php
+++ b/app/Nrgi/Mturk/Services/MechanicalTurkV2.php
@@ -2,8 +2,6 @@
 
 namespace App\Nrgi\Mturk\Services;
 
-use Carbon\Carbon;
-
 /**
  * Class MechanicalTurkV2
  */
@@ -349,12 +347,7 @@ class MechanicalTurkV2
             'headers'   => $headers,
         ];
 
-        $dt   = Carbon::now();
         $log  = new \Illuminate\Support\Facades\Log();
-        $file = storage_path().'/logs/'.'api-response'.$dt->format("Y-m-d").'-mturk.log';
-        $public_file = 'mturk-log/mturk.log';
-        $log::useFiles($file);
-        $log::useFiles($public_file);
         $log::info(json_encode($resp));
 
         return $resp;


### PR DESCRIPTION
## Why
Scheduled nightly commands, like the MTurk checks, can create log files shared with the application server. If the log files created by commands don't have the right permissions the application server will crash and the admin site becomes unusable.

## What
- [ ] the MTurk log file is owned by `www-data` whenever it is created
  - [ ] when created by scheduled commands
  - [ ] when created by `getBalance()` on the home page
  - [ ] when created by the MTurk queue when contract page tasks are submitted from the UI
  - [ ] etc...

## Notes
MTurk log file: `/var/www/rc-admin/storage/logs/api-response2021-01-27-mturk.log`.

It's actually the MTurk `artisan` queue that needs to be run as `www-data`. Here's the `supervisord` config for running the `artisan` queue:
```
[program:queue-mturk]
command=php artisan queue:work --queue=mturk --env=production --daemon --sleep=3 --tries=3
user=root
directory=/var/www/rc-admin
autostart=true
autorestart=true
stdout_logfile=/var/log/supervisor/mturk_queue.log
redirect_stderr=true
```

When new MTurk HITs are submitted before the MTurk log file is created by the app server the MTurk log file will be created by `artisan` executing the MTurk queue where HIT creation goes.

Apache error log:
```
Jan 27 10:23:52 2e8b4b866534 ecs-rc-admin-master-apache2-error.log [Wed Jan 27 08:23:52.370854 2021] [:error] [pid 12889] [client 10.0.0.194:2546] PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'The stream or file "/var/www/rc-admin/storage/logs/api-response2021-01-27-mturk.log" could not be opened in append mode: failed to open stream: Permission denied' in /var/www/rc-admin/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php:110\nStack trace:\n#0 /var/www/rc-admin/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(39): Monolog\\Handler\\StreamHandler->write(Array)\n#1 /var/www/rc-admin/vendor/monolog/monolog/src/Monolog/Logger.php(344): Monolog\\Handler\\AbstractProcessingHandler->handle(Array)\n#2 /var/www/rc-admin/vendor/monolog/monolog/src/Monolog/Logger.php(712): Monolog\\Logger->addRecord(400, Object(Symfony\\Component\\Debug\\Exception\\FatalErrorException), Array)\n#3 /var/www/rc-admin/vendor/laravel/framework/src/Illuminate/Log/Writer.php(202): Monolog\\Logger->error(Object(Symfony\\Component\\Debug\\Exception\\FatalErrorException), Array)\n#4 /var/www/rc-admin/vendor/laravel/framework/src/Illuminate/Log/Writer.php(113): in /var/www/rc-admin/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php on line 110, referer: https://admin.resourcecontracts.org/
```

The admin site does an MTurk API call every time someone logs in to check the MTurk credit balance. This uses the same log file as the MTurk scheduled commands.